### PR TITLE
Fix README server bullet

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ A powerful web-based tool that converts Markdown content into beautiful Reveal.j
 The tool runs directly in your web browser and uses CDN-hosted dependencies:
 - Reveal.js 4.5.0
 - Modern web browser with JavaScript enabled
-- localhost server, use python or visual code studio live preview add-on [[link ](https://marketplace.visualstudio.com/items?itemName=ms-vscode.live-server)
+- Local HTTP server required (e.g. `python -m http.server` or the Visual Studio Code [Live Server extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.live-server))
 
 ### Usage
 


### PR DESCRIPTION
## Summary
- fix stray bracket in the prerequisites section
- clarify that a local HTTP server is required for running `index.html`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685580758ffc8323a6dc89f91cf34a76